### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/karankraina/express-under-pressure/security/code-scanning/4](https://github.com/karankraina/express-under-pressure/security/code-scanning/4)

In general, the fix is to explicitly restrict `GITHUB_TOKEN` permissions in the workflow to the minimum required. For this workflow, neither `build` nor `publish-npm` needs to write to the GitHub repo (they mostly read code and publish to npm using a separate token), so read-only `contents` permission at the workflow level is sufficient.

The best fix without changing functionality is to add a top-level `permissions:` block (between `name:` and `on:` or right after `on:`) that applies to all jobs and sets `contents: read`. This way both `build` and `publish-npm` inherit restricted permissions, and no per-job overrides are needed. No imports or other code changes are required since this is purely YAML configuration.

Concretely, in `.github/workflows/npm-publish.yml`, add:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after line 5 or after the `on:` block), preserving indentation so that `permissions` is at the root level of the workflow definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
